### PR TITLE
Issue 4: Display the IT request category list

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,12 +10,16 @@ export interface SystemStatus {
   categories: Category[];
 }
 
-// Issue 2 — health check only. Issue 4 adds the /api/categories fetch on top.
 // Throwing on failure lets the UI show a single Offline/error state.
 export async function checkSystem(): Promise<SystemStatus> {
   const healthRes = await fetch(`${API_URL}/api/health`);
   if (!healthRes.ok) {
     throw new Error("Unable to connect to TokTickIT API");
   }
-  return { online: true, categories: [] };
+  const categoriesRes = await fetch(`${API_URL}/api/categories`);
+  if (!categoriesRes.ok) {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+  const categories: Category[] = await categoriesRes.json();
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,17 +1,48 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
 
 describe("App", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // WORKED EXAMPLE — provided for you.
   it("renders the TokTickIT heading", () => {
     render(<App />);
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText(/online/i)).toBeInTheDocument();
+    expect(screen.getByText("Account and Access")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Software")).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Unable to connect to TokTickIT API"));
+
+    render(<App />);
+    await userEvent.click(screen.getByRole("button", { name: /check system/i }));
+
+    expect(await screen.findByText(/offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/unable to connect to toktickit api/i)).toBeInTheDocument();
+  });
 });

--- a/docs/lab-01/ai_use.md
+++ b/docs/lab-01/ai_use.md
@@ -14,6 +14,7 @@
 | 6 | Write README setup instructions per Issue 1's acceptance criteria, create GitHub Issues 1–4 and the required Project board, and open the PR for Issue 1. | Documented prerequisites, Docker PostgreSQL setup, client/server install and run steps, testing commands, and environment-variable handling. Installed and authenticated the `gh` CLI, created the Issues, configured the Project's Status options, and opened PR #5. |
 | 7 | After PR #5 was approved and merged, act on reviewer `phittayanan`'s feedback and implement Issue 2. | Fixed the `server/tsconfig.json` `rootDir` bug that broke `npm run build && npm start`, implemented `GET /api/health`, wired the client's `checkSystem()`/`App.tsx` to display Online/Offline from the real API, and re-ran both test suites. |
 | 8 | Implement Issue 3: add the Prisma Category model, run the migration, and write an idempotent seed. | Added the model exactly as specified in the labsheet, ran `prisma migrate dev --name init`, implemented the seed with `prisma.category.upsert`, and verified idempotency by running it twice and confirming the row count stayed at 4. |
+| 9 | After PR #6 and PR #7 merged, implement Issue 4: GET /api/categories and wire the client to display the seeded categories. | Added the route, replaced the `describe.todo`/`it.todo` stubs with real Supertest/Vitest tests (using `vi.spyOn` on the api module for the success/error UI cases), extended `checkSystem()` to fetch categories, and verified the full stack live with `curl` against the running server. |
 
 ## Reflection
 

--- a/docs/lab-01/tests.md
+++ b/docs/lab-01/tests.md
@@ -2,15 +2,15 @@
 
 All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 
-| Test File | Tool      | Test Description                                       | Result            |
-| --------- | --------- | ------------------------------------------------------ | ----------------- |
-| API-01    | Supertest | Health endpoint returns 200 and expected JSON          | Passing           |
-| API-02    | Supertest | Categories endpoint returns the four seeded categories | Pending (Issue 4) |
-| UI-01     | Vitest    | TokTickIT heading renders                              | Passing           |
-| UI-02     | Vitest    | Loading state changes to category list                 | Pending (Issue 4) |
-| UI-03     | Vitest    | API failure displays a useful error message            | Pending (Issue 4) |
+| Test File | Tool      | Test Description                                       | Result  |
+| --------- | --------- | ------------------------------------------------------ | ------- |
+| API-01    | Supertest | Health endpoint returns 200 and expected JSON          | Passing |
+| API-02    | Supertest | Categories endpoint returns the four seeded categories | Passing |
+| UI-01     | Vitest    | TokTickIT heading renders                              | Passing |
+| UI-02     | Vitest    | Loading state changes to category list                 | Passing |
+| UI-03     | Vitest    | API failure displays a useful error message            | Passing |
 
-## Passing terminal output (as of Issue 3)
+## Passing terminal output (as of Issue 4 — all tests pass)
 
 `cd server && npm test`
 
@@ -18,11 +18,11 @@ All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 > toktickit-server@1.0.0 test
 > vitest run
 
- ↓ tests/lab-01/categories.test.ts (1 test | 1 skipped)
- ✓ tests/lab-01/health.test.ts (1 test) 18ms
+ ✓ tests/lab-01/health.test.ts (1 test) 17ms
+ ✓ tests/lab-01/categories.test.ts (1 test) 50ms
 
- Test Files  1 passed | 1 skipped (2)
-      Tests  1 passed | 1 todo (2)
+ Test Files  2 passed (2)
+      Tests  2 passed (2)
 ```
 
 `cd client && npm test`
@@ -31,10 +31,22 @@ All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
 > toktickit-client@1.0.0 test
 > vitest run
 
- ✓ tests/lab-01/App.test.tsx (3 tests | 2 skipped) 22ms
+ ✓ tests/lab-01/App.test.tsx (3 tests) 204ms
 
  Test Files  1 passed (1)
-      Tests  1 passed | 2 todo (3)
+      Tests  3 passed (3)
+```
+
+## Live end-to-end check (Issue 4)
+
+With the server running (`npm run dev`) against the seeded database:
+
+```text
+$ curl http://localhost:3000/api/health
+{"status":"ok","service":"TokTickIT API"}
+
+$ curl http://localhost:3000/api/categories
+[{"id":1,"name":"Account and Access"},{"id":2,"name":"Hardware"},{"id":3,"name":"Software"},{"id":4,"name":"Network"}]
 ```
 
 ## Issue 3 status (category seed)
@@ -48,6 +60,10 @@ All test files live under `server/tests/lab-01/` and `client/tests/lab-01/`.
   3. Software
   4. Network
 * No duplicate rows were created, confirming that the `upsert`-based seed is idempotent.
-* No automated test is required for Issue 3 itself. API-02 remains pending until Issue 4 implements `GET /api/categories` so the seeded data can be read through the API.
 
-`categories.test.ts` (API-02) and the two Issue 4 UI tests (UI-02/UI-03) remain `.todo` until Issue 4 is implemented. The table and terminal output will be updated once those tests pass.
+## Issue 4 status (category list)
+
+* `GET /api/categories` reads via `getPrisma().category.findMany(...)`, ordered by `id`, returning `{ id, name }` pairs; 500 with a safe message on failure.
+* `categories.test.ts` (API-02) now asserts the exact four seeded categories in id order — passing.
+* Client `checkSystem()` now fetches both `/api/health` and `/api/categories`; `App.tsx` renders the category list on success.
+* `App.test.tsx`'s two Issue-4 tests are implemented (`vi.spyOn(api, "checkSystem")` for success/failure) — both passing (UI-02, UI-03).

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,6 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
-// getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,13 +18,16 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({ error: "Unable to load categories" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+// Requires the DB to be migrated and seeded first (see server/prisma/seed.ts).
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: "Account and Access" },
+      { id: 2, name: "Hardware" },
+      { id: 3, name: "Software" },
+      { id: 4, name: "Network" },
+    ]);
   });
 });


### PR DESCRIPTION
Closes #4

- GET /api/categories reads via Prisma findMany, ordered by id; 500 with safe message on failure
- categories.test.ts (API-02) asserts the four seeded categories in id order - passing
- client checkSystem() now fetches /api/health + /api/categories; App.tsx renders the category list on success
- App.test.tsx's two Issue 4 tests implemented via vi.spyOn(api, checkSystem) for success/error - both passing (UI-02, UI-03)
- verified live end-to-end: curl /api/health and /api/categories against a running server with the seeded DB
- all required Lab 1 tests now pass: API-01, API-02, UI-01, UI-02, UI-03