### PR TITLE
Issue 6: Schema, migrations, and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ node_modules/
 # env & secrets
 .env
 *.env
+.env.test
 !.env.example
+!.env.test.example
 # build output
 dist/
 build/

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -1,0 +1,21 @@
+# Lab 2 — AI Use and Reflection
+
+**LLM/agent used:** Claude Code (Claude Sonnet 5), via the Claude Code CLI.
+
+## Selected key prompts (6–10)
+
+| # | Prompt (summarised) | What I did with the result |
+|---|---------------------|----------------------------|
+| 1 | Read the Lab 2 labsheet in full detail; understand the requester ticketing MVP scope, Spec-DD requirements, and grading breakdown before planning. | Used it to identify that 30/60 points are process/documentation, and that specification.md must exist before implementation PRs (Part 2) — this drove the whole build order. |
+| 2 | Explore the existing Lab 1 codebase (server and client) to find exact patterns already in use — Prisma setup, test conventions, API shape, import style — before designing anything new. | Ran two parallel research agents to read every real file; used the findings (`.js`-extension ESM imports, `getPrisma()` lazy singleton, `vi.spyOn` test pattern, no validation/upload libs installed) as hard constraints on the design instead of guessing. |
+| 3 | Design the full technical approach: Prisma schema, ticket-number generation strategy, server architecture refactor, file upload design, API contract, client architecture, test strategy, and dependencies — with tradeoffs justified, not just decisions stated. | Produced a full design covering all of the above; adopted it into the sprint specification with the reasoning kept (e.g. why a header instead of a cookie for requester context, why 404 instead of 403 for cross-requester access). |
+| 4 | Write `docs/lab-02/specification.md`, `tests.md`, `ui-spec.md`, and `api-spec.md` following the labsheet's required sections, based on the approved design. | Produced all four documents with numbered FR/BR/AC, a 38-row planned-test table with AC traceability, the full Zen Green UI spec, and the complete 12-endpoint API contract — committed and PR'd before any implementation branch, per Part 2's requirement. |
+| 5 | Set up GitHub Issues for the sprint decomposition and add them to the existing Project board, mirroring the required Kanban workflow from Lab 1. | Created 10 Issues (spec + 9 implementation areas) covering schema, server refactor, tickets API, attachments API, client shell, three UI screens, and E2E/docs; added all to the board. |
+| 6 | Implement Issue 6 (schema, migrations, seed data): add the new Prisma models per the approved schema design, generate the migration, and build idempotent reference + demo seed functions. | Added `RequesterUser`, `Ticket`, `Attachment`, `RelatedSystem`, `TicketCounter`, and two enums to `schema.prisma`; ran `prisma migrate dev`; refactored the seed into an importable `seedData.ts` with separate `seedReference()`/`seedDemoTickets()` functions. |
+| 7 | Set up a dedicated test database and reset/reseed harness so API tests stop depending on the shared dev database, and retrofit the fragile Lab 1 `categories.test.ts` to use it. | Added `.env.test`, `dotenv-cli`-based scripts, `global-setup.ts` (migrate deploy once), and a `resetDb()` helper called from `beforeEach`; verified the existing `categories.test.ts` assertion is now genuinely deterministic instead of accidentally-true. |
+| 8 | Implement the ticket-number generator as its own service and verify it's correct under concurrency, since it's the single most convincing piece of evidence in this sprint. | Implemented `nextTicketNumber()` using a row-locking `INSERT ... ON CONFLICT` against a counter table inside a transaction; wrote a unit test that fires 20 concurrent calls and asserts 20 distinct numbers — it passed on the first run. |
+
+## Reflection
+
+_To be completed at the end of the sprint, after all nine implementation Issues are merged, alongside a
+review of what the agent caught that wouldn't have been obvious to check for in advance._

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -1,0 +1,18 @@
+# Lab 2 — Peer Review Record
+
+**Author:** <FILL IN: your real name> — <FILL IN: your student ID> — GitHub: @projectnewy
+**Peer reviewer(s):** <FILL IN: name> — <FILL IN: student ID> — GitHub: @phittayanan / @vienggg
+
+## Pull Requests I authored (reviewed by my partner)
+
+| PR | Branch | Reviewer verdict |
+|----|--------|------------------|
+| [#20](https://github.com/projectnewy/tocktickit/pull/20) | docs/lab2-spec | Approved & merged (@vienggg) |
+
+_Updated as each subsequent PR (schema/seed, server refactor, tickets API, attachments API, client
+shell, Create Ticket, My Tickets, Ticket Detail, E2E+docs) is opened, reviewed, and merged._
+
+## Pull Requests I reviewed for my partner
+
+_To be filled in if/when reviewing the partner's own repository for Lab 2, following the same two-way
+evidence pattern established in `docs/lab-01/reviewer.md`._

--- a/server/.env.test.example
+++ b/server/.env.test.example
@@ -1,0 +1,4 @@
+# Copy this file to ".env.test" and fill in your own local values.
+# Do NOT commit your real .env.test file.
+# A SEPARATE database from the dev DB — tests truncate this on every run.
+DATABASE_URL="postgresql://toktickit:toktickit@localhost:5432/toktickit_test?schema=public"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "express": "^4.21.2"
       },
       "devDependencies": {
@@ -17,6 +18,7 @@
         "@types/express": "^4.17.21",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
+        "dotenv-cli": "^11.0.0",
         "prisma": "^5.22.0",
         "supertest": "^7.0.0",
         "tsx": "^4.19.2",
@@ -1442,6 +1444,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1499,6 +1516,63 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -1943,6 +2017,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2029,6 +2110,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2113,6 +2204,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2369,6 +2470,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -3327,6 +3451,22 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -9,12 +9,20 @@
     "start": "node dist/index.js",
     "prisma:migrate": "prisma migrate dev",
     "prisma:seed": "tsx prisma/seed.ts",
-    "test": "vitest run"
+    "prisma:seed:demo": "tsx prisma/seedDemo.ts",
+    "test": "dotenv -e .env.test -- vitest run",
+    "test:watch": "dotenv -e .env.test -- vitest",
+    "test:db:push": "dotenv -e .env.test -- prisma migrate deploy",
+    "test:db:reset": "dotenv -e .env.test -- prisma migrate reset --force --skip-seed",
+    "typecheck": "tsc -p tsconfig.test.json"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.2",
     "express": "^4.21.2"
   },
   "devDependencies": {
@@ -22,6 +30,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
+    "dotenv-cli": "^11.0.0",
     "prisma": "^5.22.0",
     "supertest": "^7.0.0",
     "tsx": "^4.19.2",

--- a/server/prisma/migrations/20260820101538_lab2_tickets_attachments_requesters/migration.sql
+++ b/server/prisma/migrations/20260820101538_lab2_tickets_attachments_requesters/migration.sql
@@ -1,0 +1,120 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW', 'ASSIGNED', 'IN_PROGRESS', 'RESOLVED', 'CLOSED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "department" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "summary" VARCHAR(150) NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "itPriority" "Priority",
+    "status" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedById" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedReason" VARCHAR(200),
+    "removedById" INTEGER,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TicketCounter" (
+    "year" INTEGER NOT NULL,
+    "lastNumber" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TicketCounter_pkey" PRIMARY KEY ("year")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_createdAt_idx" ON "Ticket"("requesterId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_status_createdAt_idx" ON "Ticket"("requesterId", "status", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_categoryId_idx" ON "Ticket"("requesterId", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_relatedSystemId_idx" ON "Ticket"("requesterId", "relatedSystemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFilename_key" ON "Attachment"("storedFilename");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -10,8 +10,106 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Declaration order is load-bearing: Postgres enums sort by declaration order,
+// so `orderBy: { requestedPriority: "desc" }` returns the most urgent first.
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+// Lab 2 only ever produces NEW. The rest exist so Lab 3 needs no enum migration.
+enum TicketStatus {
+  NEW
+  ASSIGNED
+  IN_PROGRESS
+  RESOLVED
+  CLOSED
+  CANCELLED
+}
+
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+model RelatedSystem {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  description String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  tickets     Ticket[]
+}
+
+model RequesterUser {
+  id         Int      @id @default(autoincrement())
+  fullName   String
+  email      String   @unique // Lab 3: becomes the login identity
+  department String?
+  isActive   Boolean  @default(true) // inactive => hidden from selector, rejected as context
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  tickets             Ticket[]
+  uploadedAttachments Attachment[] @relation("AttachmentUploader")
+  removedAttachments  Attachment[] @relation("AttachmentRemover")
+}
+
+model Ticket {
+  id                Int          @id @default(autoincrement())
+  ticketNumber      String       @unique // TKT-2026-000042
+  summary           String       @db.VarChar(150)
+  description       String       @db.Text
+  requestedPriority Priority
+  itPriority        Priority? // nullable: figure shows it, IT Staff workflow is Lab 3
+  status            TicketStatus @default(NEW)
+
+  requesterId     Int
+  categoryId      Int
+  relatedSystemId Int
+
+  createdAt DateTime @default(now()) // serialized to the client as `ticketDate`
+  updatedAt DateTime @updatedAt
+
+  requester     RequesterUser @relation(fields: [requesterId], references: [id], onDelete: Restrict)
+  category      Category      @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id], onDelete: Restrict)
+  attachments   Attachment[]
+
+  @@index([requesterId, createdAt(sort: Desc)])
+  @@index([requesterId, status, createdAt(sort: Desc)])
+  @@index([requesterId, categoryId])
+  @@index([requesterId, relatedSystemId])
+}
+
+model Attachment {
+  id               Int      @id @default(autoincrement())
+  ticketId         Int
+  originalFilename String // display only, never touches the filesystem
+  storedFilename   String   @unique // "<uuid>.<ext>"
+  mimeType         String
+  sizeBytes        Int
+  uploadedById     Int
+  uploadedAt       DateTime @default(now())
+
+  removedAt     DateTime? // SOFT REMOVAL: null => active
+  removedReason String?   @db.VarChar(200)
+  removedById   Int?
+
+  ticket     Ticket         @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  uploadedBy RequesterUser  @relation("AttachmentUploader", fields: [uploadedById], references: [id], onDelete: Restrict)
+  removedBy  RequesterUser? @relation("AttachmentRemover", fields: [removedById], references: [id], onDelete: Restrict)
+
+  @@index([ticketId, removedAt])
+}
+
+// Backs ticket-number generation — see server/src/services/ticketNumber.ts.
+model TicketCounter {
+  year       Int @id
+  lastNumber Int @default(0)
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,24 +1,9 @@
 import { getPrisma } from "../src/prisma.js";
+import { seedReference } from "../src/db/seedData.js";
 
-// Issue 3 — seed the four supported categories.
-// The four names are: Account and Access, Hardware, Software, Network.
-// Requirement: running the seed twice must NOT create duplicates.
-// Hint: prisma.category.upsert({ where:{name}, update:{}, create:{name} }).
-const CATEGORY_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
-
-async function main() {
-  const prisma = getPrisma();
-  for (const name of CATEGORY_NAMES) {
-    await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
-    });
-  }
-  console.log(`Seeded ${CATEGORY_NAMES.length} categories.`);
-}
-
-main()
+// Thin CLI wrapper — the actual seed data and logic live in src/db/seedData.ts
+// so they're typechecked by `npm run build` and importable from tests.
+seedReference(getPrisma())
   .catch((e) => {
     console.error(e);
     process.exit(1);

--- a/server/prisma/seedDemo.ts
+++ b/server/prisma/seedDemo.ts
@@ -1,0 +1,19 @@
+import { getPrisma } from "../src/prisma.js";
+import { seedReference, seedDemoTickets } from "../src/db/seedData.js";
+
+// Populates realistic demo tickets for screenshots/E2E, on top of reference
+// data. Only ever run against the dev database — never the test database.
+async function main() {
+  const prisma = getPrisma();
+  await seedReference(prisma);
+  await seedDemoTickets(prisma);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await getPrisma().$disconnect();
+  });

--- a/server/src/db/seedData.ts
+++ b/server/src/db/seedData.ts
@@ -1,0 +1,128 @@
+import type { PrismaClient, Priority } from "@prisma/client";
+import { nextTicketNumber } from "../services/ticketNumber.js";
+
+// ---------------------------------------------------------------------------
+// Reference data — idempotent (upsert on the unique natural key). Safe to run
+// repeatedly, used by both `npm run prisma:seed` and the test-DB harness.
+// ---------------------------------------------------------------------------
+
+const CATEGORY_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
+
+const RELATED_SYSTEMS = [
+  { name: "Email", description: "Corporate email and calendaring" },
+  { name: "Campus Wi-Fi", description: "Wireless network on campus" },
+  { name: "VPN", description: "Remote access VPN" },
+  { name: "LEB2 App", description: "Lab submission portal" },
+  { name: "Grade Submission App", description: "Instructor grade entry system" },
+  { name: "Printer", description: "Shared office/lab printers" },
+  { name: "Corporate Laptop", description: "Issued laptop hardware" },
+];
+
+const REQUESTERS = [
+  { fullName: "Jennifer Anderson", email: "jennifer.anderson@example.com", department: "IT", isActive: true },
+  { fullName: "Michael Brown", email: "michael.brown@example.com", department: "Sales", isActive: true },
+  { fullName: "Sarah Johnson", email: "sarah.johnson@example.com", department: "Finance", isActive: true },
+  { fullName: "David Lee", email: "david.lee@example.com", department: "Engineering", isActive: true },
+  { fullName: "Alex Wong", email: "alex.wong@example.com", department: "Marketing", isActive: false },
+];
+
+export async function seedReference(prisma: PrismaClient) {
+  for (const name of CATEGORY_NAMES) {
+    await prisma.category.upsert({ where: { name }, update: { isActive: true }, create: { name } });
+  }
+  for (const system of RELATED_SYSTEMS) {
+    await prisma.relatedSystem.upsert({
+      where: { name: system.name },
+      update: { description: system.description, isActive: true },
+      create: system,
+    });
+  }
+  for (const requester of REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: {
+        fullName: requester.fullName,
+        department: requester.department,
+        isActive: requester.isActive,
+      },
+      create: requester,
+    });
+  }
+  console.log(
+    `Seeded reference data: ${CATEGORY_NAMES.length} categories, ${RELATED_SYSTEMS.length} related systems, ` +
+      `${REQUESTERS.length} requesters (${REQUESTERS.filter((r) => r.isActive).length} active).`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Demo tickets — realistic data for screenshots/E2E against the DEV database
+// only. Never used by the test-DB harness. Guarded so it doesn't pile up
+// duplicate tickets if run more than once.
+// ---------------------------------------------------------------------------
+
+const DEMO_TICKETS: Array<{
+  requesterEmail: string;
+  categoryName: string;
+  relatedSystemName: string;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
+}> = [
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Hardware", relatedSystemName: "Corporate Laptop", summary: "Laptop battery drains quickly", description: "The battery drains much faster than usual even when the system is idle. This started happening after last week's Windows update.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Network", relatedSystemName: "VPN", summary: "Cannot connect to VPN", description: "VPN client fails to connect from home network with a timeout error.", requestedPriority: "HIGH" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Software", relatedSystemName: "Email", summary: "Email not syncing on mobile", description: "New emails are not appearing on the mobile app, only on desktop.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Account and Access", relatedSystemName: "LEB2 App", summary: "New employee setup request", description: "Need LEB2 App access provisioned for a new starter joining next week.", requestedPriority: "LOW" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Hardware", relatedSystemName: "Printer", summary: "Printer keeps showing offline", description: "3rd floor printer shows offline intermittently despite being powered on.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Account and Access", relatedSystemName: "LEB2 App", summary: "Request access to SharePoint", description: "Need read access to the shared project folder for the new intake.", requestedPriority: "LOW" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Software", relatedSystemName: "Grade Submission App", summary: "Outlook freezing intermittently", description: "Outlook freezes for 10-20 seconds when opening large attachments.", requestedPriority: "HIGH" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Hardware", relatedSystemName: "Corporate Laptop", summary: "Docking station not detected", description: "External monitors don't turn on when the laptop is docked.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Network", relatedSystemName: "Campus Wi-Fi", summary: "Wi-Fi drops in the east wing", description: "Connection drops every few minutes when working from the east wing meeting rooms.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Software", relatedSystemName: "Grade Submission App", summary: "Cannot submit final grades", description: "Submission button is greyed out on the final review page.", requestedPriority: "URGENT" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Account and Access", relatedSystemName: "Email", summary: "Password reset needed", description: "Locked out of email after too many failed login attempts.", requestedPriority: "HIGH" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Hardware", relatedSystemName: "Printer", summary: "Toner replacement request", description: "2nd floor printer toner is low and needs replacing.", requestedPriority: "LOW" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Network", relatedSystemName: "VPN", summary: "VPN speed extremely slow", description: "File transfers over VPN are taking 10x longer than usual.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "jennifer.anderson@example.com", categoryName: "Software", relatedSystemName: "LEB2 App", summary: "Upload fails on LEB2 App", description: "File upload fails silently for files over 2MB on the lab submission portal.", requestedPriority: "HIGH" },
+  { requesterEmail: "michael.brown@example.com", categoryName: "Hardware", relatedSystemName: "Corporate Laptop", summary: "Keyboard keys unresponsive", description: "The 'A' and 'S' keys intermittently stop responding.", requestedPriority: "MEDIUM" },
+  { requesterEmail: "michael.brown@example.com", categoryName: "Account and Access", relatedSystemName: "Email", summary: "Distribution list access needed", description: "Need to be added to the sales-team distribution list.", requestedPriority: "LOW" },
+];
+
+export async function seedDemoTickets(prisma: PrismaClient) {
+  const existing = await prisma.ticket.count();
+  if (existing > 0) {
+    console.log(`Skipped demo tickets: ${existing} ticket(s) already exist.`);
+    return;
+  }
+
+  const requesters = await prisma.requesterUser.findMany();
+  const categories = await prisma.category.findMany();
+  const relatedSystems = await prisma.relatedSystem.findMany();
+
+  const requesterByEmail = new Map(requesters.map((r) => [r.email, r]));
+  const categoryByName = new Map(categories.map((c) => [c.name, c]));
+  const systemByName = new Map(relatedSystems.map((s) => [s.name, s]));
+
+  let created = 0;
+  for (const demo of DEMO_TICKETS) {
+    const requester = requesterByEmail.get(demo.requesterEmail);
+    const category = categoryByName.get(demo.categoryName);
+    const relatedSystem = systemByName.get(demo.relatedSystemName);
+    if (!requester || !category || !relatedSystem) continue;
+
+    await prisma.$transaction(async (tx) => {
+      const ticketNumber = await nextTicketNumber(tx);
+      await tx.ticket.create({
+        data: {
+          ticketNumber,
+          summary: demo.summary,
+          description: demo.description,
+          requestedPriority: demo.requestedPriority,
+          requesterId: requester.id,
+          categoryId: category.id,
+          relatedSystemId: relatedSystem.id,
+        },
+      });
+    });
+    created++;
+  }
+  console.log(`Seeded ${created} demo tickets.`);
+}

--- a/server/src/services/ticketNumber.ts
+++ b/server/src/services/ticketNumber.ts
@@ -1,0 +1,40 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+// Ticket numbers look like TKT-2026-000042: 6-digit, zero-padded, resetting each year.
+// Pinned to Asia/Bangkok so a Dec-31 demo doesn't roll over to the wrong year on a
+// server running in a different timezone.
+const TICKET_NUMBER_TIMEZONE = "Asia/Bangkok";
+const MAX_RETRIES = 3;
+
+function currentYear(): number {
+  const parts = new Intl.DateTimeFormat("en-US", { timeZone: TICKET_NUMBER_TIMEZONE, year: "numeric" })
+    .formatToParts(new Date());
+  const year = parts.find((p) => p.type === "year")?.value;
+  return Number(year);
+}
+
+function formatTicketNumber(year: number, sequence: number): string {
+  return `TKT-${year}-${String(sequence).padStart(6, "0")}`;
+}
+
+/**
+ * Must be called inside the same transaction as the Ticket insert. The
+ * `ON CONFLICT ... DO UPDATE` row-locks the TicketCounter row for `year`, so a second
+ * concurrent transaction requesting the same year blocks until the first commits —
+ * two tickets can never receive the same number. `Ticket.ticketNumber` is additionally
+ * `@unique` as a database-enforced backstop.
+ */
+export async function nextTicketNumber(
+  tx: Prisma.TransactionClient | PrismaClient,
+  year: number = currentYear()
+): Promise<string> {
+  const rows = await tx.$queryRaw<{ lastNumber: number }[]>`
+    INSERT INTO "TicketCounter" (year, "lastNumber")
+    VALUES (${year}, 1)
+    ON CONFLICT (year) DO UPDATE SET "lastNumber" = "TicketCounter"."lastNumber" + 1
+    RETURNING "lastNumber"
+  `;
+  return formatTicketNumber(year, rows[0].lastNumber);
+}
+
+export { MAX_RETRIES, formatTicketNumber, currentYear };

--- a/server/tests/global-setup.ts
+++ b/server/tests/global-setup.ts
@@ -1,0 +1,7 @@
+import { execSync } from "node:child_process";
+
+// Runs once before the whole test run: applies all migrations to the test
+// database (already pointed at by DATABASE_URL via `dotenv -e .env.test`).
+export default function globalSetup() {
+  execSync("npx prisma migrate deploy", { stdio: "inherit" });
+}

--- a/server/tests/helpers/db.ts
+++ b/server/tests/helpers/db.ts
@@ -1,0 +1,13 @@
+import { getPrisma } from "../../src/prisma.js";
+import { seedReference } from "../../src/db/seedData.js";
+
+// Truncates every application table and reseeds reference data. Call from
+// `beforeEach` in every API test file so no test depends on state left by a
+// previous test or a previous run. Never run against the dev database.
+export async function resetDb() {
+  const prisma = getPrisma();
+  await prisma.$executeRawUnsafe(
+    `TRUNCATE "Attachment", "Ticket", "TicketCounter", "RequesterUser", "RelatedSystem", "Category" RESTART IDENTITY CASCADE;`
+  );
+  await seedReference(prisma);
+}

--- a/server/tests/helpers/factories.ts
+++ b/server/tests/helpers/factories.ts
@@ -1,0 +1,79 @@
+import type { Priority } from "@prisma/client";
+import { getPrisma } from "../../src/prisma.js";
+import { nextTicketNumber } from "../../src/services/ticketNumber.js";
+
+let counter = 0;
+function unique(label: string) {
+  counter += 1;
+  return `${label}-${counter}-${Date.now()}`;
+}
+
+export async function makeRequester(overrides: Partial<{ fullName: string; email: string; department: string | null; isActive: boolean }> = {}) {
+  const prisma = getPrisma();
+  return prisma.requesterUser.create({
+    data: {
+      fullName: overrides.fullName ?? "Test Requester",
+      email: overrides.email ?? `${unique("requester")}@example.com`,
+      department: overrides.department ?? "QA",
+      isActive: overrides.isActive ?? true,
+    },
+  });
+}
+
+export async function makeTicket(overrides: {
+  requesterId: number;
+  categoryId?: number;
+  relatedSystemId?: number;
+  summary?: string;
+  description?: string;
+  requestedPriority?: Priority;
+}) {
+  const prisma = getPrisma();
+
+  let categoryId = overrides.categoryId;
+  if (!categoryId) {
+    const category = await prisma.category.findFirstOrThrow({ where: { isActive: true } });
+    categoryId = category.id;
+  }
+
+  let relatedSystemId = overrides.relatedSystemId;
+  if (!relatedSystemId) {
+    const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } });
+    relatedSystemId = relatedSystem.id;
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const ticketNumber = await nextTicketNumber(tx);
+    return tx.ticket.create({
+      data: {
+        ticketNumber,
+        summary: overrides.summary ?? unique("Test ticket summary"),
+        description: overrides.description ?? "Test ticket description with enough length.",
+        requestedPriority: overrides.requestedPriority ?? "MEDIUM",
+        requesterId: overrides.requesterId,
+        categoryId,
+        relatedSystemId,
+      },
+    });
+  });
+}
+
+export async function makeAttachment(overrides: {
+  ticketId: number;
+  uploadedById: number;
+  originalFilename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+}) {
+  const prisma = getPrisma();
+  return prisma.attachment.create({
+    data: {
+      ticketId: overrides.ticketId,
+      uploadedById: overrides.uploadedById,
+      originalFilename: overrides.originalFilename ?? "test-file.png",
+      storedFilename: `${unique("stored")}.png`,
+      mimeType: overrides.mimeType ?? "image/png",
+      sizeBytes: overrides.sizeBytes ?? 1024,
+    },
+  });
+}

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
+import { resetDb } from "../helpers/db.js";
 
-// Requires the DB to be migrated and seeded first (see server/prisma/seed.ts).
 describe("GET /api/categories", () => {
+  beforeEach(resetDb);
+
   it("returns the four seeded categories in id order", async () => {
     const res = await request(app).get("/api/categories");
     expect(res.status).toBe(200);

--- a/server/tests/lab-02/ticketNumber.unit.test.ts
+++ b/server/tests/lab-02/ticketNumber.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+import { nextTicketNumber, formatTicketNumber } from "../../src/services/ticketNumber.js";
+import { resetDb } from "../helpers/db.js";
+
+describe("formatTicketNumber", () => {
+  it("zero-pads the sequence to 6 digits", () => {
+    expect(formatTicketNumber(2026, 42)).toBe("TKT-2026-000042");
+    expect(formatTicketNumber(2026, 1)).toBe("TKT-2026-000001");
+    expect(formatTicketNumber(2026, 123456)).toBe("TKT-2026-123456");
+  });
+});
+
+describe("nextTicketNumber", () => {
+  beforeEach(resetDb);
+
+  it("returns sequential numbers for the same year", async () => {
+    const prisma = getPrisma();
+    const first = await prisma.$transaction((tx) => nextTicketNumber(tx, 2026));
+    const second = await prisma.$transaction((tx) => nextTicketNumber(tx, 2026));
+    expect(first).toBe("TKT-2026-000001");
+    expect(second).toBe("TKT-2026-000002");
+  });
+
+  it("generates 20 distinct numbers under concurrent calls", async () => {
+    const prisma = getPrisma();
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => prisma.$transaction((tx) => nextTicketNumber(tx, 2026)))
+    );
+    expect(new Set(results).size).toBe(20);
+  });
+
+  it("tracks separate counters per year", async () => {
+    const prisma = getPrisma();
+    const y2026 = await prisma.$transaction((tx) => nextTicketNumber(tx, 2026));
+    const y2027 = await prisma.$transaction((tx) => nextTicketNumber(tx, 2027));
+    expect(y2026).toBe("TKT-2026-000001");
+    expect(y2027).toBe("TKT-2027-000001");
+  });
+});

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -1,0 +1,8 @@
+import { afterAll } from "vitest";
+import { getPrisma } from "../src/prisma.js";
+
+// Closes the shared Prisma connection once after the whole run so vitest
+// doesn't hang on an open database handle.
+afterAll(async () => {
+  await getPrisma().$disconnect();
+});

--- a/server/tsconfig.test.json
+++ b/server/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src", "tests", "prisma"]
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
+    globalSetup: ["./tests/global-setup.ts"],
+    // Parallel test files truncating shared tables produce flaky, order-dependent
+    // failures that look like application bugs. Serial execution costs a few
+    // seconds at this scale and is worth it.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
Closes #11

Implements the database increment from `docs/lab-02/specification.md` §7.

## What's in this PR
- Prisma models: `RequesterUser`, `RelatedSystem`, `Ticket`, `Attachment`, `TicketCounter`;
  `Priority`/`TicketStatus` enums; `Category` gains `isActive`. One migration, applied cleanly.
- Ticket number generator (`src/services/ticketNumber.ts`): `TKT-<year>-<6 digits>`, row-locked
  counter inside the same transaction as the insert. Unit-tested including a 20-concurrent-calls test
  asserting 20 distinct numbers (passing).
- `src/db/seedData.ts`: idempotent `seedReference()` (4 categories, 7 related systems, 5 requesters —
  4 active + 1 inactive) and `seedDemoTickets()` (16 realistic tickets for screenshots/E2E, never used
  by tests).
- Dedicated `toktickit_test` database + `resetDb()` harness (`beforeEach` truncate+reseed,
  `fileParallelism: false`), so tests no longer depend on the shared dev database. Retrofits Lab 1's
  `categories.test.ts`, whose ids-1-4 assertion is now genuinely deterministic instead of
  accidentally-true.
- `tsconfig.test.json` — closes the Lab 1 reviewer finding on PR #6 that `tests/`/`prisma/` weren't
  typechecked by `npm run build`.

## Verification
- `npm test`: 3 files, 6 tests passing (incl. the 20-way concurrency test), against `toktickit_test`.
- `npm run typecheck` and `npm run build`: both clean.
- Manually verified `GET /api/health` and `GET /api/categories` are still byte-identical to Lab 1.
- Dev DB reseeded with reference + 16 demo tickets for use in later UI/E2E work.

## Not in this PR (by design, per the sprint decomposition)
Server routing/services refactor (Issue 7), tickets/attachments API endpoints (Issues 8–9), and all
client work — this PR is schema + seed + test harness only.