### PR TITLE
Issue 8: Tickets API

### DIFF
--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -17,6 +17,8 @@
 
 | 9 | Implement Issue 7 (server refactor): restructure `app.ts` from two inline routes into routers/services/error-handling middleware, add `/api/related-systems` and `/api/requesters`, while keeping `/api/health` and `/api/categories` byte-identical. | Built `src/http/{errors,asyncHandler,requesterContext,errorHandler,notFound}.ts`, `src/routes/{health,reference}.routes.ts`, `src/services/reference.service.ts`, `src/env.ts`; verified byte-identical Lab 1 responses via `npm run build && node dist/index.js` plus curl, and confirmed `npm start` still works (the exact class of bug flagged on Lab 1 PR #5/#6). |
 
+| 10 | Implement Issue 8 (tickets API): create/list/detail endpoints with the ticket-number generator, ownership enforcement, and query validation from the spec. Write the API tests, including the 20-concurrent-creates test. | Built `src/validation/ticket.schemas.ts` (zod), `src/services/ticket.service.ts`, `src/routes/tickets.routes.ts`; wrote 3 test files (17 new tests). Running them caught a real bug — mounting `requesterContext` as bare router-level middleware made it fire for every request through that router, including an unrelated 404 for a nonexistent route, which started returning 401 instead. Fixed by mounting the router at a `/tickets` path prefix instead of unprefixed. Confirmed live end-to-end via `curl` against the built `dist/` app, including a real ticket creation and list-with-pagination against the seeded demo data. |
+
 ## Reflection
 
 _To be completed at the end of the sprint, after all nine implementation Issues are merged, alongside a

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,10 +1,16 @@
 import { Router } from "express";
 import healthRouter from "./health.routes.js";
 import referenceRouter from "./reference.routes.js";
+import ticketsRouter from "./tickets.routes.js";
 
-// Ticket and attachment routers are added in Issues 8–9.
+// Attachment router is added in Issue 9.
 const router = Router();
 router.use(healthRouter);
 router.use(referenceRouter);
+// Mounted at a path prefix (not bare `router.use(ticketsRouter)`) so that
+// ticketsRouter's requesterContext middleware only ever runs for /tickets/*
+// requests — mounting it unprefixed made requesterContext fire for every
+// request through this router, including unrelated 404s (caught by a test).
+router.use("/tickets", ticketsRouter);
 
 export default router;

--- a/server/src/routes/tickets.routes.ts
+++ b/server/src/routes/tickets.routes.ts
@@ -1,0 +1,41 @@
+import { Router } from "express";
+import { asyncHandler } from "../http/asyncHandler.js";
+import { requesterContext } from "../http/requesterContext.js";
+import { BadRequestError } from "../http/errors.js";
+import { createTicketSchema, ticketQuerySchema } from "../validation/ticket.schemas.js";
+import * as ticketService from "../services/ticket.service.js";
+
+const router = Router();
+router.use(requesterContext);
+
+router.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const input = createTicketSchema.parse(req.body);
+    const ticket = await ticketService.createTicket(req.requesterId!, input);
+    res.status(201).json(ticket);
+  })
+);
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const query = ticketQuerySchema.parse(req.query);
+    const result = await ticketService.listTickets(req.requesterId!, query);
+    res.status(200).json(result);
+  })
+);
+
+router.get(
+  "/:ticketId",
+  asyncHandler(async (req, res) => {
+    const ticketId = Number(req.params.ticketId);
+    if (!Number.isInteger(ticketId) || ticketId <= 0) {
+      throw new BadRequestError("Invalid ticket id");
+    }
+    const ticket = await ticketService.getTicketById(req.requesterId!, ticketId);
+    res.status(200).json(ticket);
+  })
+);
+
+export default router;

--- a/server/src/services/ticket.service.ts
+++ b/server/src/services/ticket.service.ts
@@ -1,0 +1,211 @@
+import { Prisma } from "@prisma/client";
+import { getPrisma } from "../prisma.js";
+import { nextTicketNumber } from "./ticketNumber.js";
+import { BadRequestError, NotFoundError } from "../http/errors.js";
+import type { CreateTicketInput, TicketQuery } from "../validation/ticket.schemas.js";
+
+const TICKET_DETAIL_SELECT = {
+  id: true,
+  ticketNumber: true,
+  summary: true,
+  description: true,
+  requestedPriority: true,
+  itPriority: true,
+  status: true,
+  createdAt: true,
+  requester: { select: { id: true, fullName: true } },
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+  attachments: {
+    select: {
+      id: true,
+      ticketId: true,
+      originalFilename: true,
+      mimeType: true,
+      sizeBytes: true,
+      uploadedAt: true,
+      removedAt: true,
+      removedReason: true,
+      uploadedBy: { select: { id: true, fullName: true } },
+      removedBy: { select: { id: true, fullName: true } },
+    },
+    orderBy: { uploadedAt: "asc" as const },
+  },
+} satisfies Prisma.TicketSelect;
+
+type TicketDetailRow = Prisma.TicketGetPayload<{ select: typeof TICKET_DETAIL_SELECT }>;
+
+function serializeAttachment(a: TicketDetailRow["attachments"][number]) {
+  return {
+    id: a.id,
+    ticketId: a.ticketId,
+    originalFilename: a.originalFilename,
+    mimeType: a.mimeType,
+    sizeBytes: a.sizeBytes,
+    uploadedAt: a.uploadedAt,
+    uploadedBy: a.uploadedBy,
+    isRemoved: a.removedAt !== null,
+    removedAt: a.removedAt,
+    removedReason: a.removedReason,
+    removedBy: a.removedBy,
+  };
+}
+
+function serializeTicket(t: TicketDetailRow) {
+  return {
+    id: t.id,
+    ticketNumber: t.ticketNumber,
+    summary: t.summary,
+    description: t.description,
+    requestedPriority: t.requestedPriority,
+    itPriority: t.itPriority,
+    status: t.status,
+    ticketDate: t.createdAt,
+    requester: t.requester,
+    category: t.category,
+    relatedSystem: t.relatedSystem,
+    // No IT Staff model exists yet in Lab 2 — see specification.md §11.
+    ticketOwner: null as { id: number; fullName: string } | null,
+    attachments: t.attachments.map(serializeAttachment),
+  };
+}
+
+const MAX_TICKET_NUMBER_RETRIES = 3;
+
+export async function createTicket(requesterId: number, input: CreateTicketInput) {
+  const prisma = getPrisma();
+  const [category, relatedSystem] = await Promise.all([
+    prisma.category.findFirst({ where: { id: input.categoryId, isActive: true } }),
+    prisma.relatedSystem.findFirst({ where: { id: input.relatedSystemId, isActive: true } }),
+  ]);
+  if (!category) throw new BadRequestError("Unknown or inactive category");
+  if (!relatedSystem) throw new BadRequestError("Unknown or inactive related system");
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_TICKET_NUMBER_RETRIES; attempt++) {
+    try {
+      const ticket = await prisma.$transaction(async (tx) => {
+        const ticketNumber = await nextTicketNumber(tx);
+        return tx.ticket.create({
+          data: {
+            ticketNumber,
+            summary: input.summary,
+            description: input.description,
+            requestedPriority: input.requestedPriority,
+            requesterId,
+            categoryId: input.categoryId,
+            relatedSystemId: input.relatedSystemId,
+          },
+          select: TICKET_DETAIL_SELECT,
+        });
+      });
+      return serializeTicket(ticket);
+    } catch (err) {
+      lastError = err;
+      // P2002 on ticketNumber is the only case worth retrying (see
+      // specification.md §7 — the counter table makes this vanishingly rare,
+      // this is a backstop, not the primary correctness mechanism).
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") continue;
+      throw err;
+    }
+  }
+  throw lastError;
+}
+
+const SORT_MAP: Record<string, Prisma.TicketOrderByWithRelationInput> = {
+  "createdAt:desc": { createdAt: "desc" },
+  "createdAt:asc": { createdAt: "asc" },
+  "ticketNumber:asc": { ticketNumber: "asc" },
+  "ticketNumber:desc": { ticketNumber: "desc" },
+  "requestedPriority:desc": { requestedPriority: "desc" },
+  "requestedPriority:asc": { requestedPriority: "asc" },
+  "summary:asc": { summary: "asc" },
+  "summary:desc": { summary: "desc" },
+};
+
+function endOfDay(date: Date): Date {
+  return new Date(date.getTime() + 24 * 60 * 60 * 1000 - 1);
+}
+
+export async function listTickets(requesterId: number, query: TicketQuery) {
+  const prisma = getPrisma();
+
+  const where: Prisma.TicketWhereInput = {
+    requesterId,
+    ...(query.status?.length ? { status: { in: query.status } } : {}),
+    ...(query.categoryId ? { categoryId: query.categoryId } : {}),
+    ...(query.relatedSystemId ? { relatedSystemId: query.relatedSystemId } : {}),
+    ...(query.requestedPriority?.length ? { requestedPriority: { in: query.requestedPriority } } : {}),
+    ...(query.q
+      ? {
+          OR: [
+            { ticketNumber: { contains: query.q, mode: "insensitive" as const } },
+            { summary: { contains: query.q, mode: "insensitive" as const } },
+          ],
+        }
+      : {}),
+    ...(query.dateFrom || query.dateTo
+      ? {
+          createdAt: {
+            ...(query.dateFrom ? { gte: query.dateFrom } : {}),
+            ...(query.dateTo ? { lte: endOfDay(query.dateTo) } : {}),
+          },
+        }
+      : {}),
+  };
+
+  const [items, totalItems] = await prisma.$transaction([
+    prisma.ticket.findMany({
+      where,
+      orderBy: SORT_MAP[query.sort],
+      skip: (query.page - 1) * query.pageSize,
+      take: query.pageSize,
+      select: {
+        id: true,
+        ticketNumber: true,
+        createdAt: true,
+        summary: true,
+        category: { select: { id: true, name: true } },
+        relatedSystem: { select: { id: true, name: true } },
+        requestedPriority: true,
+        status: true,
+        _count: { select: { attachments: { where: { removedAt: null } } } },
+      },
+    }),
+    prisma.ticket.count({ where }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalItems / query.pageSize));
+
+  return {
+    items: items.map((t) => ({
+      id: t.id,
+      ticketNumber: t.ticketNumber,
+      ticketDate: t.createdAt,
+      summary: t.summary,
+      category: t.category,
+      relatedSystem: t.relatedSystem,
+      requestedPriority: t.requestedPriority,
+      status: t.status,
+      activeAttachmentCount: t._count.attachments,
+    })),
+    page: query.page,
+    pageSize: query.pageSize,
+    totalItems,
+    totalPages,
+    hasPreviousPage: query.page > 1,
+    hasNextPage: query.page < totalPages,
+    sort: query.sort,
+  };
+}
+
+export async function getTicketById(requesterId: number, ticketId: number) {
+  const ticket = await getPrisma().ticket.findFirst({
+    where: { id: ticketId, requesterId },
+    select: TICKET_DETAIL_SELECT,
+  });
+  // Same response whether the id doesn't exist or belongs to a different
+  // requester — see specification.md §11 on why 404 rather than 403.
+  if (!ticket) throw new NotFoundError("Ticket not found");
+  return serializeTicket(ticket);
+}

--- a/server/src/validation/ticket.schemas.ts
+++ b/server/src/validation/ticket.schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const VALID_PAGE_SIZES = [10, 20, 50] as const;
+
+export const SORT_ALLOWLIST = [
+  "createdAt:desc",
+  "createdAt:asc",
+  "ticketNumber:asc",
+  "ticketNumber:desc",
+  "requestedPriority:desc",
+  "requestedPriority:asc",
+  "summary:asc",
+  "summary:desc",
+] as const;
+
+const STATUS_VALUES = ["NEW", "ASSIGNED", "IN_PROGRESS", "RESOLVED", "CLOSED", "CANCELLED"] as const;
+const PRIORITY_VALUES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+
+export const createTicketSchema = z.object({
+  categoryId: z.coerce.number().int().positive(),
+  relatedSystemId: z.coerce.number().int().positive(),
+  summary: z.string().trim().min(5, "Summary must be at least 5 characters").max(150, "Summary must be at most 150 characters"),
+  description: z.string().trim().min(10, "Description must be at least 10 characters").max(4000, "Description must be at most 4000 characters"),
+  requestedPriority: z.enum(PRIORITY_VALUES),
+});
+
+// A single value comes through as a string; a repeated param (?status=A&status=B)
+// comes through as an array already — normalise both to an array before validating.
+const toArray = (value: unknown) => (value === undefined ? undefined : Array.isArray(value) ? value : [value]);
+
+export const ticketQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce
+    .number()
+    .refine((value): value is (typeof VALID_PAGE_SIZES)[number] => (VALID_PAGE_SIZES as readonly number[]).includes(value), {
+      message: "pageSize must be 10, 20, or 50",
+    })
+    .default(10),
+  q: z.string().trim().max(100).optional(),
+  status: z.preprocess(toArray, z.array(z.enum(STATUS_VALUES)).optional()),
+  categoryId: z.coerce.number().int().positive().optional(),
+  relatedSystemId: z.coerce.number().int().positive().optional(),
+  requestedPriority: z.preprocess(toArray, z.array(z.enum(PRIORITY_VALUES)).optional()),
+  dateFrom: z.coerce.date().optional(),
+  dateTo: z.coerce.date().optional(),
+  sort: z.enum(SORT_ALLOWLIST).default("createdAt:desc"),
+});
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;
+export type TicketQuery = z.infer<typeof ticketQuerySchema>;

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { resetDb } from "../helpers/db.js";
+import { makeRequester } from "../helpers/factories.js";
+import { getPrisma } from "../../src/prisma.js";
+
+const VALID_TICKET = {
+  categoryId: 2, // Hardware
+  relatedSystemId: 7, // Corporate Laptop
+  summary: "Laptop battery drains quickly",
+  description: "The battery drains much faster than usual even when the system is idle.",
+  requestedPriority: "MEDIUM",
+};
+
+describe("POST /api/tickets", () => {
+  beforeEach(resetDb);
+
+  it("creates a ticket with a unique, backend-generated ticket number and status NEW (API-01)", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send(VALID_TICKET);
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("NEW");
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+    expect(res.body.requester).toEqual({ id: 1, fullName: "Jennifer Anderson" });
+    expect(res.body.attachments).toEqual([]);
+
+    const saved = await getPrisma().ticket.findUnique({ where: { id: res.body.id } });
+    expect(saved?.requesterId).toBe(1);
+  });
+
+  it("generates 20 distinct ticket numbers under 20 concurrent creates (API-02)", async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        request(app).post("/api/tickets").set("X-Requester-Id", "1").send(VALID_TICKET)
+      )
+    );
+
+    for (const res of responses) expect(res.status).toBe(201);
+    const numbers = responses.map((res) => res.body.ticketNumber);
+    expect(new Set(numbers).size).toBe(20);
+  });
+
+  it("rejects missing/invalid fields with field-level details and creates nothing (API-03)", async () => {
+    const before = await getPrisma().ticket.count();
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", "1")
+      .send({ categoryId: 2, relatedSystemId: 7, summary: "hi", description: "short", requestedPriority: "SUPER" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details.length).toBeGreaterThan(0);
+    expect(await getPrisma().ticket.count()).toBe(before);
+  });
+
+  it("rejects an inactive category reference (API-04)", async () => {
+    await getPrisma().category.updateMany({ where: { id: 2 }, data: { isActive: false } });
+    const res = await request(app).post("/api/tickets").set("X-Requester-Id", "1").send(VALID_TICKET);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a request with no requester context (API-05)", async () => {
+    const res = await request(app).post("/api/tickets").send(VALID_TICKET);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a request whose requester id belongs to an inactive requester (API-05, AC-18)", async () => {
+    const inactive = await makeRequester({ isActive: false });
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(inactive.id))
+      .send(VALID_TICKET);
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { resetDb } from "../helpers/db.js";
+import { makeRequester, makeTicket } from "../helpers/factories.js";
+
+describe("GET /api/tickets", () => {
+  beforeEach(resetDb);
+
+  it("lists only the selected requester's tickets, newest first, with correct pagination metadata (API-06)", async () => {
+    const other = await makeRequester();
+    for (let i = 0; i < 3; i++) await makeTicket({ requesterId: 1 });
+    await makeTicket({ requesterId: other.id });
+
+    const res = await request(app).get("/api/tickets").set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBe(3);
+    expect(res.body.totalItems).toBe(3);
+    const dates = res.body.items.map((t: { ticketDate: string }) => new Date(t.ticketDate).getTime());
+    expect(dates).toEqual([...dates].sort((a, b) => b - a));
+  });
+
+  it("searches by ticketNumber and by summary substring (API-07)", async () => {
+    const ticket = await makeTicket({ requesterId: 1, summary: "Cannot connect to VPN" });
+    await makeTicket({ requesterId: 1, summary: "Printer offline" });
+
+    const byNumber = await request(app)
+      .get("/api/tickets")
+      .query({ q: ticket.ticketNumber })
+      .set("X-Requester-Id", "1");
+    expect(byNumber.body.items.map((t: { id: number }) => t.id)).toEqual([ticket.id]);
+
+    const bySummary = await request(app).get("/api/tickets").query({ q: "vpn" }).set("X-Requester-Id", "1");
+    expect(bySummary.body.items.map((t: { id: number }) => t.id)).toEqual([ticket.id]);
+  });
+
+  it("filters by category, relatedSystem, requestedPriority, and status, individually and combined (API-08)", async () => {
+    const t1 = await makeTicket({ requesterId: 1, categoryId: 2, requestedPriority: "HIGH" });
+    await makeTicket({ requesterId: 1, categoryId: 3, requestedPriority: "LOW" });
+
+    const byCategory = await request(app).get("/api/tickets").query({ categoryId: 2 }).set("X-Requester-Id", "1");
+    expect(byCategory.body.items.map((t: { id: number }) => t.id)).toEqual([t1.id]);
+
+    const combined = await request(app)
+      .get("/api/tickets")
+      .query({ categoryId: 2, requestedPriority: "HIGH" })
+      .set("X-Requester-Id", "1");
+    expect(combined.body.items.map((t: { id: number }) => t.id)).toEqual([t1.id]);
+
+    const noMatch = await request(app)
+      .get("/api/tickets")
+      .query({ categoryId: 2, requestedPriority: "LOW" })
+      .set("X-Requester-Id", "1");
+    expect(noMatch.body.items).toEqual([]);
+  });
+
+  it("sorts by ticketNumber, summary, and requestedPriority in both directions (API-09)", async () => {
+    await makeTicket({ requesterId: 1, summary: "Beta issue" });
+    await makeTicket({ requesterId: 1, summary: "Alpha issue" });
+
+    const asc = await request(app).get("/api/tickets").query({ sort: "summary:asc" }).set("X-Requester-Id", "1");
+    expect(asc.body.items.map((t: { summary: string }) => t.summary)).toEqual(["Alpha issue", "Beta issue"]);
+
+    const desc = await request(app).get("/api/tickets").query({ sort: "summary:desc" }).set("X-Requester-Id", "1");
+    expect(desc.body.items.map((t: { summary: string }) => t.summary)).toEqual(["Beta issue", "Alpha issue"]);
+  });
+
+  it("returns an empty page for a filter combination matching nothing (API-10)", async () => {
+    await makeTicket({ requesterId: 1, categoryId: 2 });
+    const res = await request(app).get("/api/tickets").query({ categoryId: 3 }).set("X-Requester-Id", "1");
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.totalItems).toBe(0);
+  });
+
+  it("rejects invalid query parameters instead of silently coercing them (API-11)", async () => {
+    const badPage = await request(app).get("/api/tickets").query({ page: "abc" }).set("X-Requester-Id", "1");
+    expect(badPage.status).toBe(400);
+
+    const badPageSize = await request(app).get("/api/tickets").query({ pageSize: "10000" }).set("X-Requester-Id", "1");
+    expect(badPageSize.status).toBe(400);
+
+    const badSort = await request(app).get("/api/tickets").query({ sort: "nope:asc" }).set("X-Requester-Id", "1");
+    expect(badSort.status).toBe(400);
+  });
+
+  it("computes activeAttachmentCount and pagination metadata across two pages (AC-08)", async () => {
+    for (let i = 0; i < 14; i++) await makeTicket({ requesterId: 1 });
+
+    const page1 = await request(app).get("/api/tickets").query({ page: 1, pageSize: 10 }).set("X-Requester-Id", "1");
+    expect(page1.body.items.length).toBe(10);
+    expect(page1.body.totalItems).toBe(14);
+    expect(page1.body.totalPages).toBe(2);
+    expect(page1.body.hasNextPage).toBe(true);
+    expect(page1.body.hasPreviousPage).toBe(false);
+
+    const page2 = await request(app).get("/api/tickets").query({ page: 2, pageSize: 10 }).set("X-Requester-Id", "1");
+    expect(page2.body.items.length).toBe(4);
+    expect(page2.body.hasNextPage).toBe(false);
+    expect(page2.body.hasPreviousPage).toBe(true);
+  });
+});

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { resetDb } from "../helpers/db.js";
+import { makeRequester, makeTicket } from "../helpers/factories.js";
+
+describe("GET /api/tickets/:ticketId", () => {
+  beforeEach(resetDb);
+
+  it("retrieves one owned ticket with its attachments array (API-12)", async () => {
+    const ticket = await makeTicket({ requesterId: 1 });
+    const res = await request(app).get(`/api/tickets/${ticket.id}`).set("X-Requester-Id", "1");
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ticket.id);
+    expect(res.body.attachments).toEqual([]);
+  });
+
+  it("rejects access to a ticket owned by a different requester with 404 and no ticket data (API-13, AC-03)", async () => {
+    const owner = await makeRequester();
+    const ticket = await makeTicket({ requesterId: owner.id });
+
+    const res = await request(app).get(`/api/tickets/${ticket.id}`).set("X-Requester-Id", "1");
+
+    expect(res.status).toBe(404);
+    expect(res.body).not.toHaveProperty("summary");
+    expect(res.body).not.toHaveProperty("description");
+  });
+
+  it("returns the identical 404 shape for a nonexistent ticket id (API-14)", async () => {
+    const owner = await makeRequester();
+    const ownedTicket = await makeTicket({ requesterId: owner.id });
+
+    const notOwned = await request(app).get(`/api/tickets/${ownedTicket.id}`).set("X-Requester-Id", "1");
+    const notFound = await request(app).get("/api/tickets/999999").set("X-Requester-Id", "1");
+
+    expect(notOwned.status).toBe(404);
+    expect(notFound.status).toBe(404);
+    expect(notOwned.body).toEqual(notFound.body);
+  });
+
+  it("rejects a non-numeric ticket id", async () => {
+    const res = await request(app).get("/api/tickets/not-a-number").set("X-Requester-Id", "1");
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Closes #13

Implements ticket create/list/detail per `api-spec.md` §4-6.

## What's in this PR
- `POST /api/tickets`, `GET /api/tickets` (search/filter/sort/pagination), `GET /api/tickets/:ticketId`
- Ticket number generator wired from Issue 6 (`TKT-<year>-<6 digits>`), with a bounded 3-try retry on
  `P2002` as a backstop
- Ownership is always a `where` predicate (`findFirst({ where: { id, requesterId } })`), never
  fetch-then-compare
- Cross-requester access returns `404`, byte-identical to a nonexistent id — asserted in tests, not
  just documented
- Ticket-list query validated via zod: `page/pageSize(10,20,50 allowlist)/q/status/categoryId/
  relatedSystemId/requestedPriority/dateFrom/dateTo/sort(8-value allowlist)`; invalid params rejected
  with `400`, never silently coerced

## A real bug the test suite caught
Mounting `requesterContext` as bare router-level middleware (`router.use(requesterContext)` with the
router itself mounted unprefixed) made it fire for **every** request passing through that part of the
middleware chain — including an unrelated `GET /api/nonexistent-route`, which started returning `401`
instead of the expected `404`. A test written for the 404 case caught it immediately. Fixed by mounting
`tickets.routes.ts` at an explicit `/tickets` path prefix in `routes/index.ts`, so the middleware only
ever runs for actual ticket requests.

## Verification
- `npm test`: 7 files, **26 tests passing**, including 20 concurrent `POST /api/tickets` producing 20
  distinct ticket numbers.
- `npm run typecheck` and `npm run build`: both clean.
- Live end-to-end via `curl` against the built `dist/` app: created a real ticket, then listed it back
  with correct pagination against the seeded demo data (15 tickets, 2 pages).

## Not in this PR
Attachment endpoints (Issue 9) — the tickets response already has an `attachments: []` slot ready for
them.